### PR TITLE
add multi object yaml support

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -12,8 +13,13 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var creationTimeStampRegexp *regexp.Regexp
+var statusRegexp *regexp.Regexp
+
 func init() {
 
+	creationTimeStampRegexp = regexp.MustCompile(`.*creationTimestamp.*\n`)
+	statusRegexp = regexp.MustCompile(`status:[\s\S]*?(?:---|$)`)
 	createCmd.Flags().StringVarP(&Provider, "provider", "p", "", "provider to use (required)")
 	_ = createCmd.MarkFlagRequired("provider")
 	createCmd.Flags().StringVarP(&Filename, "filename", "f", "", "filename to use (required)")

--- a/commands/create.go
+++ b/commands/create.go
@@ -14,12 +14,10 @@ import (
 )
 
 var creationTimeStampRegexp *regexp.Regexp
-var statusRegexp *regexp.Regexp
 
 func init() {
 
 	creationTimeStampRegexp = regexp.MustCompile(`.*creationTimestamp.*\n`)
-	statusRegexp = regexp.MustCompile(`status:[\s\S]*?(?:---|$)`)
 	createCmd.Flags().StringVarP(&Provider, "provider", "p", "", "provider to use (required)")
 	_ = createCmd.MarkFlagRequired("provider")
 	createCmd.Flags().StringVarP(&Filename, "filename", "f", "", "filename to use (required)")
@@ -63,6 +61,8 @@ var createCmd = &cobra.Command{
 		}
 
 		yaml := utils.RemoveStatus(newEncrypted)
+		yaml = creationTimeStampRegexp.ReplaceAll(yaml, nil)
+
 		err = os.WriteFile(Filename, yaml, 0600)
 		if err != nil {
 			return fmt.Errorf("error writing EncryptedSecret %s", err)

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"regexp"
 
-	"github.com/opensecrecy/cryptctl/commands/utils"
 	"github.com/opensecrecy/encrypted-secrets/pkg/providers"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -75,7 +75,7 @@ var editCmd = &cobra.Command{
 		}
 
 		// yamlData holds the final yaml to be written to the file
-		yamlData := []byte{}
+		var yamlData []byte
 
 		newEncrypted, err := yaml.Marshal(&encryptedObj)
 		if err != nil {

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -104,7 +104,7 @@ var editCmd = &cobra.Command{
 		result := utils.RemoveStatus(newEncrypted)
 
 		// finally, write the encryptedSecret yaml
-		err = os.WriteFile(fileName, []byte(result), 0600)
+		err = os.WriteFile(fileName, result, 0600)
 		if err != nil {
 			return fmt.Errorf("error writing EncryptedSecret %s", err)
 		}

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -7,10 +7,9 @@ import (
 	"os/exec"
 	"regexp"
 
+	"github.com/opensecrecy/cryptctl/commands/utils"
 	"github.com/opensecrecy/encrypted-secrets/pkg/providers"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/yaml"
 
@@ -38,33 +37,14 @@ var editCmd = &cobra.Command{
 	},
 	RunE: func(_ *cobra.Command, args []string) error {
 		fileName := args[0]
-		encryptedFile, err := os.ReadFile(fileName)
+		// parse the encryptedSecret
+		objs, err := utils.ParseYaml(fileName)
 		if err != nil {
-			return fmt.Errorf("error reading file %s", err.Error())
-		}
-
-		codecs := serializer.NewCodecFactory(scheme.Scheme, serializer.EnableStrict)
-		obj, _, err := codecs.UniversalDeserializer().Decode(encryptedFile, &schema.GroupVersionKind{
-			Group:   secretsv1alpha1.GroupVersion.Group,
-			Version: SecretApiVersion,
-			Kind:    "EncryptedSecret",
-		}, nil)
-		if err != nil {
-			if ok, _ := regexp.MatchString("no kind(.*)is registered for version", err.Error()); ok {
-				panic("no kind(.*)is registered for version")
-			}
-			panic(err)
-		}
-
-		// convert the runtimeObj to encryptedSecret object
-		encryptedSecret, ok := obj.(*secretsv1alpha1.EncryptedSecret)
-		if !ok {
-			// should never happen
-			panic("failed to convert runtimeObject to encryptedSecret")
+			return fmt.Errorf("error parsing encryptedSecret %s", err.Error())
 		}
 
 		// get the decryptedSecret
-		decryptedObj, err := providers.DecodeAndDecrypt(encryptedSecret)
+		decryptedObj, err := providers.DecodeAndDecrypt(&objs.EncryptedSecret)
 		if err != nil {
 			return fmt.Errorf("failed to decrypt value for %s", err.Error())
 		}
@@ -95,17 +75,36 @@ var editCmd = &cobra.Command{
 			return fmt.Errorf("error encrypting new secrets %s", err)
 		}
 
-		// write the contents to yaml
+		// yamlData holds the final yaml to be written to the file
+		yamlData := []byte{}
+
 		newEncrypted, err := yaml.Marshal(&encryptedObj)
 		if err != nil {
 			return fmt.Errorf("error marshaling encryptedSecret %s", err.Error())
+		}
+		yamlData = append(yamlData, newEncrypted...)
+
+		for _, k8sobj := range objs.Objects {
+			// decode the object
+			decode := scheme.Codecs.UniversalDeserializer().Decode
+			decodedObj, _, _ := decode([]byte(k8sobj), nil, nil)
+
+			// marshal the object
+			objData, err := yaml.Marshal(decodedObj)
+			if err != nil {
+				return fmt.Errorf("error marshaling object %s", err.Error())
+			}
+
+			// Append the separator '---' and the object data
+			yamlData = append(yamlData, []byte("---\n")...)
+			yamlData = append(yamlData, objData...)
 		}
 
 		// remove status field from the object
 		result := utils.RemoveStatus(newEncrypted)
 
 		// finally, write the encryptedSecret yaml
-		err = os.WriteFile(fileName, result, 0600)
+		err = os.WriteFile(fileName, []byte(result), 0600)
 		if err != nil {
 			return fmt.Errorf("error writing EncryptedSecret %s", err)
 		}

--- a/commands/edit.go
+++ b/commands/edit.go
@@ -81,7 +81,10 @@ var editCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error marshaling encryptedSecret %s", err.Error())
 		}
-		yamlData = append(yamlData, newEncrypted...)
+		// remove status field from the object
+		result := utils.RemoveStatus(newEncrypted)
+
+		yamlData = append(yamlData, result...)
 
 		for _, k8sobj := range objs.Objects {
 			// decode the object
@@ -99,11 +102,8 @@ var editCmd = &cobra.Command{
 			yamlData = append(yamlData, objData...)
 		}
 
-		// remove status field from the object
-		result := utils.RemoveStatus(newEncrypted)
-
 		// finally, write the encryptedSecret yaml
-		err = os.WriteFile(fileName, result, 0600)
+		err = os.WriteFile(fileName, yamlData, 0600)
 		if err != nil {
 			return fmt.Errorf("error writing EncryptedSecret %s", err)
 		}

--- a/commands/utils/file.go
+++ b/commands/utils/file.go
@@ -39,8 +39,8 @@ func ParseYaml(filename string) (*Objects, error) {
 		Kind:    "EncryptedSecret",
 	}, nil)
 	if err != nil {
-		if ok, _ := regexp.MatchString("no kind(.*)is registered for version", err.Error()); ok {
-			panic("no kind(.*)is registered for version")
+		if ok, _ := regexp.MatchString("no kind (.*) is registered for version", err.Error()); ok {
+			panic("no kind (.*) is registered for version")
 		}
 		panic(err)
 	}

--- a/commands/utils/file.go
+++ b/commands/utils/file.go
@@ -1,0 +1,59 @@
+// this file contains the file related functions
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	secretsv1alpha1 "github.com/opensecrecy/encrypted-secrets/api/v1alpha1"
+)
+
+const (
+	SecretApiVersion = "secrets.shubhindia.xyz/v1alpha1"
+)
+
+type Objects struct {
+	EncryptedSecret secretsv1alpha1.EncryptedSecret
+	Objects         []string
+}
+
+func ParseYaml(filename string) (*Objects, error) {
+	encryptedFile, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %s", err.Error())
+	}
+
+	yamlDocuments := strings.Split(string(encryptedFile), "---\n")
+
+	codecs := serializer.NewCodecFactory(scheme.Scheme, serializer.EnableStrict)
+	obj, _, err := codecs.UniversalDeserializer().Decode([]byte(yamlDocuments[0]), &schema.GroupVersionKind{
+		Group:   secretsv1alpha1.GroupVersion.Group,
+		Version: SecretApiVersion,
+		Kind:    "EncryptedSecret",
+	}, nil)
+	if err != nil {
+		if ok, _ := regexp.MatchString("no kind(.*)is registered for version", err.Error()); ok {
+			panic("no kind(.*)is registered for version")
+		}
+		panic(err)
+	}
+	// convert the runtimeObj to encryptedSecret object
+	encryptedSecret, ok := obj.(*secretsv1alpha1.EncryptedSecret)
+	if !ok {
+		// should never happen
+		panic("failed to convert runtimeObject to encryptedSecret")
+	}
+
+	objs := Objects{
+		EncryptedSecret: *encryptedSecret,
+		Objects:         yamlDocuments[1:],
+	}
+	return &objs, nil
+}


### PR DESCRIPTION
This adds support for editing a yaml which has multiple k8s objects inside and not only `EncryptedSecrets`.
Current limitations:
1. The `EncryptedSecret` object must be the first object in the yaml.
2. Other objects are not available for editing i.e. `cryptctl edit` won't open them in text editor.